### PR TITLE
chore(backend): upgrade to Spring Boot 4.0 / Java 25

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.9-eclipse-temurin-17 AS build
+FROM maven:3.9-eclipse-temurin-25 AS build
 WORKDIR /app
 COPY pom.xml .
 COPY .mvn .mvn
@@ -7,7 +7,7 @@ RUN mvn dependency:go-offline -B
 COPY src ./src
 RUN mvn package -DskipTests -B
 
-FROM eclipse-temurin:17-jre-alpine
+FROM eclipse-temurin:25-jre-alpine
 WORKDIR /app
 COPY --from=build /app/target/*.jar app.jar
 EXPOSE 8080

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.3</version>
+        <version>4.0.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.example</groupId>
@@ -27,13 +27,13 @@
         <url/>
     </scm>
     <properties>
-        <java.version>17</java.version>
+        <java.version>25</java.version>
     </properties>
     <dependencies>
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.0.4</version>
+            <version>3.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -60,7 +60,6 @@
         <dependency>
             <groupId>jakarta.persistence</groupId>
             <artifactId>jakarta.persistence-api</artifactId>
-            <version>3.1.0</version>
         </dependency>
         <dependency>
             <groupId>jakarta.validation</groupId>
@@ -75,6 +74,19 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -58,6 +58,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>jakarta.persistence</groupId>
             <artifactId>jakarta.persistence-api</artifactId>
         </dependency>

--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -1,0 +1,11 @@
+spring.datasource.url=jdbc:h2:mem:libman;DB_CLOSE_DELAY=-1;MODE=PostgreSQL
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=false
+spring.jpa.open-in-view=false
+spring.sql.init.mode=never
+spring.security.user.name=test
+spring.security.user.password=test
+app.cors.allowed-origins=http://localhost:5173


### PR DESCRIPTION
## Summary

Rolls the backend up to **Spring Boot 4.0.0** on **Java 25** (Spring Framework 7, Hibernate 7.1, Jakarta EE 11 / JPA 3.2). Verified locally: compiles, packages a runnable jar, and the full Spring context boots during tests under Hibernate 7.1.8.

## Changes

**Upgrade (`c3f4655`)**
- Spring Boot parent `3.3.3` → `4.0.0`; `java.version` `17` → `25`
- springdoc-openapi `2.0.4` → `3.0.0` (2.x is incompatible with Boot 4)
- Drop pinned `jakarta.persistence-api 3.1.0` so the Boot 4 BOM manages JPA 3.2
- Declare Lombok in `maven-compiler-plugin` `annotationProcessorPaths` — JDK 23+ no longer runs classpath annotation processors implicitly, so without this every Lombok-generated accessor fails to compile
- Dockerfile build + runtime base images → Temurin 25

**Test enablement (`ee934f6`)**
- Add test-scoped H2 + `src/test/resources/application.properties` (in-memory, `ddl-auto=create-drop`) so `contextLoads` actually boots the context and exercises the Hibernate 7 entity mappings. (The test was previously unrunnable — no datasource configured — on Boot 3 too.)

## Verification

- ✅ `mvn clean test` → BUILD SUCCESS (1 test), context boots under Hibernate 7.1.8 on JDK 25
- ✅ `mvn package` builds the runnable jar (Docker build path)
- ⚠️ Runtime exercised against in-memory H2 only (no Docker daemon available locally for Postgres). **Recommend a smoke test against real Postgres before merge** — the Hibernate 7.1 detached-entity reassociation change touches the book/author merge paths; compiled-clean and boots clean, but not yet run against PG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)