### PR TITLE
Backend modernization after Java 25 / Spring Boot 4 upgrade

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -81,6 +81,26 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-java-25</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                    <version>[25,)</version>
+                                    <message>This project requires JDK 25 or newer. Set JAVA_HOME to a JDK 25 installation.</message>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <annotationProcessorPaths>

--- a/backend/src/main/java/com/example/backend/controller/AuthorController.java
+++ b/backend/src/main/java/com/example/backend/controller/AuthorController.java
@@ -3,7 +3,7 @@ package com.example.backend.controller;
 import com.example.backend.dto.AuthorDTO;
 import com.example.backend.service.authors.IAuthorService;
 import jakarta.validation.Valid;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -12,9 +12,9 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/authors")
+@RequiredArgsConstructor
 public class AuthorController {
-    @Autowired
-    private IAuthorService authorService;
+    private final IAuthorService authorService;
 
     @GetMapping({"", "/"})
     public List<AuthorDTO> getAllAuthors() {

--- a/backend/src/main/java/com/example/backend/controller/BookController.java
+++ b/backend/src/main/java/com/example/backend/controller/BookController.java
@@ -3,7 +3,7 @@ package com.example.backend.controller;
 import com.example.backend.dto.BookDTO;
 import com.example.backend.service.books.IBookService;
 import jakarta.validation.Valid;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -12,9 +12,9 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/books")
+@RequiredArgsConstructor
 public class BookController {
-    @Autowired
-    private IBookService bookService;
+    private final IBookService bookService;
 
     @GetMapping({"", "/"})
     public List<BookDTO> getAllBooks() {

--- a/backend/src/main/java/com/example/backend/controller/BorrowerController.java
+++ b/backend/src/main/java/com/example/backend/controller/BorrowerController.java
@@ -4,7 +4,7 @@ import com.example.backend.dto.BorrowerDTO;
 import com.example.backend.dto.BorrowerPatchDTO;
 import com.example.backend.service.borrowers.IBorrowerService;
 import jakarta.validation.Valid;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -13,9 +13,9 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/borrowers")
+@RequiredArgsConstructor
 public class BorrowerController {
-    @Autowired
-    private IBorrowerService borrowerService;
+    private final IBorrowerService borrowerService;
 
     @GetMapping({"", "/"})
     public List<BorrowerDTO.BorrowerSummaryDTO> getAllBorrowers() {

--- a/backend/src/main/java/com/example/backend/controller/BorrowingController.java
+++ b/backend/src/main/java/com/example/backend/controller/BorrowingController.java
@@ -3,7 +3,7 @@ package com.example.backend.controller;
 import com.example.backend.dto.BorrowingDTO;
 import com.example.backend.service.borrowing.IBorrowingService;
 import jakarta.validation.Valid;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -12,10 +12,10 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/borrowings")
+@RequiredArgsConstructor
 public class BorrowingController {
 
-    @Autowired
-    private IBorrowingService borrowingService;
+    private final IBorrowingService borrowingService;
 
     @GetMapping({"", "/"})
     public ResponseEntity<List<BorrowingDTO>> getAllBorrowings() {

--- a/backend/src/main/java/com/example/backend/dto/AuthorDTO.java
+++ b/backend/src/main/java/com/example/backend/dto/AuthorDTO.java
@@ -2,36 +2,31 @@ package com.example.backend.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
 import java.util.Set;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
-public class AuthorDTO {
-    private Long authorId;
+public record AuthorDTO(
+        Long authorId,
 
-    @NotBlank(message = "Name is required")
-    @Size(max = 255, message = "Name must be less than 255 characters")
-    private String name;
+        @NotBlank(message = "Name is required")
+        @Size(max = 255, message = "Name must be less than 255 characters")
+        String name,
 
-    @Size(max = 50, message = "Nationality must be less than 50 characters")
-    private String nationality;
+        @Size(max = 50, message = "Nationality must be less than 50 characters")
+        String nationality,
 
-    private String portraitUrl;
+        String portraitUrl,
 
-    private Set<BookDTO.BookSummaryDTO> books;
-
-    @Data
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class AuthorSummaryDTO {
-        private Long id;
-        private String name;
-        private String nationality;
-        private String portraitUrl;
+        Set<BookDTO.BookSummaryDTO> books
+) {
+    public AuthorDTO withBooks(Set<BookDTO.BookSummaryDTO> books) {
+        return new AuthorDTO(authorId, name, nationality, portraitUrl, books);
     }
+
+    public record AuthorSummaryDTO(
+            Long id,
+            String name,
+            String nationality,
+            String portraitUrl
+    ) {}
 }

--- a/backend/src/main/java/com/example/backend/dto/BookDTO.java
+++ b/backend/src/main/java/com/example/backend/dto/BookDTO.java
@@ -5,41 +5,38 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
 import java.util.Set;
 
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
-public class BookDTO {
-    private Long bookId;
+public record BookDTO(
+        Long bookId,
 
-    @NotBlank(message = "Title is required")
-    @Size(max = 255, message = "Title must be less than 255 characters")
-    private String title;
+        @NotBlank(message = "Title is required")
+        @Size(max = 255, message = "Title must be less than 255 characters")
+        String title,
 
-    @NotBlank(message = "ISBN is required")
-    @Size(min = 10, max = 13, message = "ISBN must be between 10 and 13 characters")
-    private String isbn;
+        @NotBlank(message = "ISBN is required")
+        @Size(min = 10, max = 13, message = "ISBN must be between 10 and 13 characters")
+        String isbn,
 
-    @NotNull(message = "Publication year is required")
-    @Min(value = 1000, message = "Publication year must be at least 1000")
-    private Integer publicationYear;
+        @NotNull(message = "Publication year is required")
+        @Min(value = 1000, message = "Publication year must be at least 1000")
+        Integer publicationYear,
 
-    private Set<AuthorDTO.AuthorSummaryDTO> authors;
-    private String status;
-    private String coverImageUrl;
+        Set<AuthorDTO.AuthorSummaryDTO> authors,
 
-    @Data
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class BookSummaryDTO {
-        private Long id;
-        private String title;
-        private String isbn;
-        private Book.BookStatus status;
+        String status,
+
+        String coverImageUrl
+) {
+    public BookDTO withAuthors(Set<AuthorDTO.AuthorSummaryDTO> authors) {
+        return new BookDTO(bookId, title, isbn, publicationYear, authors, status, coverImageUrl);
     }
+
+    public record BookSummaryDTO(
+            Long id,
+            String title,
+            String isbn,
+            Book.BookStatus status
+    ) {}
 }

--- a/backend/src/main/java/com/example/backend/dto/BorrowerDTO.java
+++ b/backend/src/main/java/com/example/backend/dto/BorrowerDTO.java
@@ -3,49 +3,46 @@ package com.example.backend.dto;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.Set;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
-public class BorrowerDTO {
-    private Long borrowerId;
+public record BorrowerDTO(
+        Long borrowerId,
 
-    @NotBlank(message = "Name is required")
-    @Size(max = 255, message = "Name must be less than 255 characters")
-    private String name;
+        @NotBlank(message = "Name is required")
+        @Size(max = 255, message = "Name must be less than 255 characters")
+        String name,
 
-    @NotBlank(message = "Email is required")
-    @Email(message = "Invalid email format")
-    private String email;
+        @NotBlank(message = "Email is required")
+        @Email(message = "Invalid email format")
+        String email,
 
-    @Size(max = 50, message = "Phone number must be less than 50 characters")
-    private String phone;
+        @Size(max = 50, message = "Phone number must be less than 50 characters")
+        String phone,
 
-    @Size(max = 255, message = "Address must be less than 255 characters")
-    private String address;
+        @Size(max = 255, message = "Address must be less than 255 characters")
+        String address,
 
-    @NotBlank(message = "Status is required")
-    private String status;
+        @NotBlank(message = "Status is required")
+        String status,
 
-    private Set<BorrowingDTO> borrowings;
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
+        Set<BorrowingDTO> borrowings,
 
-    @Data
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class BorrowerSummaryDTO {
-        private Long id;
-        private String name;
-        private String email;
-        private String phone;
-        private String address;
-        private String status;
+        LocalDateTime createdAt,
+
+        LocalDateTime updatedAt
+) {
+    public BorrowerDTO withBorrowings(Set<BorrowingDTO> borrowings) {
+        return new BorrowerDTO(borrowerId, name, email, phone, address, status, borrowings, createdAt, updatedAt);
     }
+
+    public record BorrowerSummaryDTO(
+            Long id,
+            String name,
+            String email,
+            String phone,
+            String address,
+            String status
+    ) {}
 }

--- a/backend/src/main/java/com/example/backend/dto/BorrowerPatchDTO.java
+++ b/backend/src/main/java/com/example/backend/dto/BorrowerPatchDTO.java
@@ -2,26 +2,19 @@ package com.example.backend.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Size;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
-public class BorrowerPatchDTO {
+public record BorrowerPatchDTO(
+        @Size(max = 255, message = "Name must be less than 255 characters")
+        String name,
 
-    @Size(max = 255, message = "Name must be less than 255 characters")
-    private String name;
+        @Email(message = "Invalid email format")
+        String email,
 
-    @Email(message = "Invalid email format")
-    private String email;
+        @Size(max = 50, message = "Phone number must be less than 50 characters")
+        String phone,
 
-    @Size(max = 50, message = "Phone number must be less than 50 characters")
-    private String phone;
+        @Size(max = 255, message = "Address must be less than 255 characters")
+        String address,
 
-    @Size(max = 255, message = "Address must be less than 255 characters")
-    private String address;
-
-    private String status;
-}
+        String status
+) {}

--- a/backend/src/main/java/com/example/backend/dto/BorrowingDTO.java
+++ b/backend/src/main/java/com/example/backend/dto/BorrowingDTO.java
@@ -1,29 +1,16 @@
 package com.example.backend.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
-public class BorrowingDTO {
-    private Long borrowingId;
-
-    private Long bookId;
-
-    private Long borrowerId;
-
-    private LocalDate borrowedDate = LocalDate.now();
-
-    private LocalDate dueDate;
-
-    private LocalDate returnedDate;
-
-    private LocalDate createdAt;
-    private LocalDate updatedAt;
-
-    private String status;
-}
+public record BorrowingDTO(
+        Long borrowingId,
+        Long bookId,
+        Long borrowerId,
+        LocalDate borrowedDate,
+        LocalDate dueDate,
+        LocalDate returnedDate,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt,
+        String status
+) {}

--- a/backend/src/main/java/com/example/backend/mapper/LibraryMapper.java
+++ b/backend/src/main/java/com/example/backend/mapper/LibraryMapper.java
@@ -10,26 +10,25 @@ import com.example.backend.model.Borrower;
 import com.example.backend.model.Borrowing;
 import org.springframework.stereotype.Component;
 
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Component
 public class LibraryMapper {
     public BookDTO toBookDTO(Book book) {
-        BookDTO bookDTO = new BookDTO();
-        bookDTO.setBookId(book.getBookId());
-        bookDTO.setTitle(book.getTitle());
-        bookDTO.setIsbn(book.getIsbn());
-        bookDTO.setPublicationYear(book.getPublicationYear());
-
-        if (book.getAuthors() != null) {
-            bookDTO.setAuthors(book.getAuthors().stream()
-                    .map(this::toAuthorSummaryDTO)
-                    .collect(Collectors.toSet()));
-        }
-
-        bookDTO.setStatus(book.getStatus().name());
-        bookDTO.setCoverImageUrl(book.getCoverImageUrl());
-        return bookDTO;
+        Set<AuthorDTO.AuthorSummaryDTO> authors = book.getAuthors() == null ? null :
+                book.getAuthors().stream()
+                        .map(this::toAuthorSummaryDTO)
+                        .collect(Collectors.toSet());
+        return new BookDTO(
+                book.getBookId(),
+                book.getTitle(),
+                book.getIsbn(),
+                book.getPublicationYear(),
+                authors,
+                book.getStatus().name(),
+                book.getCoverImageUrl()
+        );
     }
 
     public BookDTO.BookSummaryDTO toBookSummaryDTO(Book book) {
@@ -42,19 +41,17 @@ public class LibraryMapper {
     }
 
     public AuthorDTO toAuthorDTO(Author author) {
-        AuthorDTO authorDTO = new AuthorDTO();
-        authorDTO.setAuthorId(author.getAuthorId());
-        authorDTO.setName(author.getName());
-        authorDTO.setNationality(author.getNationality());
-        authorDTO.setPortraitUrl(author.getPortraitUrl());
-
-        if (author.getBooks() != null) {
-            authorDTO.setBooks(author.getBooks().stream()
-                    .map(this::toBookSummaryDTO)
-                    .collect(Collectors.toSet()));
-        }
-
-        return authorDTO;
+        Set<BookDTO.BookSummaryDTO> books = author.getBooks() == null ? null :
+                author.getBooks().stream()
+                        .map(this::toBookSummaryDTO)
+                        .collect(Collectors.toSet());
+        return new AuthorDTO(
+                author.getAuthorId(),
+                author.getName(),
+                author.getNationality(),
+                author.getPortraitUrl(),
+                books
+        );
     }
 
     public AuthorDTO.AuthorSummaryDTO toAuthorSummaryDTO(Author author) {
@@ -68,42 +65,46 @@ public class LibraryMapper {
 
     public Author toAuthorEntity(AuthorDTO authorDTO) {
         Author author = new Author();
-        author.setName(authorDTO.getName());
-        author.setNationality(authorDTO.getNationality());
-        author.setPortraitUrl(authorDTO.getPortraitUrl());
+        author.setName(authorDTO.name());
+        author.setNationality(authorDTO.nationality());
+        author.setPortraitUrl(authorDTO.portraitUrl());
         return author;
     }
 
     public BorrowingDTO toBorrowingDTO(Borrowing borrowing) {
-        BorrowingDTO borrowingDTO = new BorrowingDTO();
-        borrowingDTO.setBorrowingId(borrowing.getBorrowingId());
-        borrowingDTO.setBookId(borrowing.getBook().getBookId());
-        borrowingDTO.setBorrowerId(borrowing.getBorrower().getBorrowerId());
-        borrowingDTO.setBorrowedDate(borrowing.getBorrowedDate());
-        borrowingDTO.setDueDate(borrowing.getDueDate());
-        borrowingDTO.setReturnedDate(borrowing.getReturnedDate());
-        borrowingDTO.setStatus(borrowing.getStatus().name());
-        return borrowingDTO;
+        return new BorrowingDTO(
+                borrowing.getBorrowingId(),
+                borrowing.getBook().getBookId(),
+                borrowing.getBorrower().getBorrowerId(),
+                borrowing.getBorrowedDate(),
+                borrowing.getDueDate(),
+                borrowing.getReturnedDate(),
+                borrowing.getCreatedAt(),
+                borrowing.getUpdatedAt(),
+                borrowing.getStatus().name()
+        );
     }
 
-
     public BorrowerDTO toBorrowerDTO(Borrower borrower) {
-        BorrowerDTO borrowerDTO = new BorrowerDTO();
-        borrowerDTO.setBorrowerId(borrower.getBorrowerId());
-        borrowerDTO.setName(borrower.getName());
-        borrowerDTO.setEmail(borrower.getEmail());
-        borrowerDTO.setPhone(borrower.getPhone());
-        borrowerDTO.setAddress(borrower.getAddress());
-        borrowerDTO.setStatus(borrower.getStatus().name());
-        return borrowerDTO;
+        return new BorrowerDTO(
+                borrower.getBorrowerId(),
+                borrower.getName(),
+                borrower.getEmail(),
+                borrower.getPhone(),
+                borrower.getAddress(),
+                borrower.getStatus().name(),
+                null,
+                borrower.getCreatedAt(),
+                borrower.getUpdatedAt()
+        );
     }
 
     public Borrower toBorrowerEntity(BorrowerDTO borrowerDTO) {
         Borrower borrower = new Borrower();
-        borrower.setName(borrowerDTO.getName());
-        borrower.setEmail(borrowerDTO.getEmail());
-        borrower.setPhone(borrowerDTO.getPhone());
-        borrower.setAddress(borrowerDTO.getAddress());
+        borrower.setName(borrowerDTO.name());
+        borrower.setEmail(borrowerDTO.email());
+        borrower.setPhone(borrowerDTO.phone());
+        borrower.setAddress(borrowerDTO.address());
         return borrower;
     }
 

--- a/backend/src/main/java/com/example/backend/model/Borrowing.java
+++ b/backend/src/main/java/com/example/backend/model/Borrowing.java
@@ -9,6 +9,7 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "borrowings")
@@ -45,11 +46,11 @@ public class Borrowing {
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
-    private LocalDate createdAt;
+    private LocalDateTime createdAt;
 
     @UpdateTimestamp
     @Column(name = "updated_at", nullable = false)
-    private LocalDate updatedAt;
+    private LocalDateTime updatedAt;
 
     public enum BorrowingStatus {
         BORROWED,

--- a/backend/src/main/java/com/example/backend/model/Borrowing.java
+++ b/backend/src/main/java/com/example/backend/model/Borrowing.java
@@ -23,11 +23,11 @@ public class Borrowing {
     @Column(name = "borrowing_id")
     private Long borrowingId;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "book_id", nullable = false)
     private Book book;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "borrower_id", nullable = false)
     private Borrower borrower;
 

--- a/backend/src/main/java/com/example/backend/service/authors/AuthorService.java
+++ b/backend/src/main/java/com/example/backend/service/authors/AuthorService.java
@@ -6,9 +6,9 @@ import com.example.backend.mapper.LibraryMapper;
 import com.example.backend.model.Author;
 import com.example.backend.model.Book;
 import com.example.backend.repository.AuthorRepository;
+import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,14 +16,13 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
+@RequiredArgsConstructor
 public class AuthorService implements IAuthorService {
     private static final Logger logger = LoggerFactory.getLogger(AuthorService.class);
 
-    @Autowired
-    private AuthorRepository authorRepository;
+    private final AuthorRepository authorRepository;
 
-    @Autowired
-    private LibraryMapper libraryMapper;
+    private final LibraryMapper libraryMapper;
 
     @Override
     @Transactional(readOnly = true)

--- a/backend/src/main/java/com/example/backend/service/authors/AuthorService.java
+++ b/backend/src/main/java/com/example/backend/service/authors/AuthorService.java
@@ -30,12 +30,11 @@ public class AuthorService implements IAuthorService {
         logger.info("Fetching all authors from the database");
         return authorRepository.findByDeletedFalse().stream()
                 .map(author -> {
-                    AuthorDTO authorDTO = libraryMapper.toAuthorDTO(author);
                     List<Book> books = authorRepository.findActiveBooksByAuthorId(author.getAuthorId());
-                    authorDTO.setBooks(books.stream()
-                            .map(libraryMapper::toBookSummaryDTO)
-                            .collect(Collectors.toSet()));
-                    return authorDTO;
+                    return libraryMapper.toAuthorDTO(author)
+                            .withBooks(books.stream()
+                                    .map(libraryMapper::toBookSummaryDTO)
+                                    .collect(Collectors.toSet()));
                 }).collect(Collectors.toList());
     }
 
@@ -45,12 +44,11 @@ public class AuthorService implements IAuthorService {
         logger.info("Fetching author with id: {}", authorId);
         Author author = authorRepository.findById(authorId)
                 .orElseThrow(() -> new ResourceNotFoundException("Author not found with id: " + authorId));
-        AuthorDTO authorDTO = libraryMapper.toAuthorDTO(author);
         List<Book> books = authorRepository.findBooksByAuthorId(author.getAuthorId());
-        authorDTO.setBooks(books.stream()
-                .map(libraryMapper::toBookSummaryDTO)
-                .collect(Collectors.toSet()));
-        return authorDTO;
+        return libraryMapper.toAuthorDTO(author)
+                .withBooks(books.stream()
+                        .map(libraryMapper::toBookSummaryDTO)
+                        .collect(Collectors.toSet()));
     }
 
     @Override
@@ -73,14 +71,14 @@ public class AuthorService implements IAuthorService {
             throw new IllegalStateException("Cannot update a deleted author");
         }
 
-        if (authorDTO.getName() != null) {
-            existingAuthor.setName(authorDTO.getName());
+        if (authorDTO.name() != null) {
+            existingAuthor.setName(authorDTO.name());
         }
-        if (authorDTO.getNationality() != null) {
-            existingAuthor.setNationality(authorDTO.getNationality());
+        if (authorDTO.nationality() != null) {
+            existingAuthor.setNationality(authorDTO.nationality());
         }
-        if (authorDTO.getPortraitUrl() != null) {
-            existingAuthor.setPortraitUrl(authorDTO.getPortraitUrl());
+        if (authorDTO.portraitUrl() != null) {
+            existingAuthor.setPortraitUrl(authorDTO.portraitUrl());
         }
 
         Author updatedAuthor = authorRepository.save(existingAuthor);

--- a/backend/src/main/java/com/example/backend/service/books/BookService.java
+++ b/backend/src/main/java/com/example/backend/service/books/BookService.java
@@ -8,9 +8,9 @@ import com.example.backend.model.Author;
 import com.example.backend.model.Book;
 import com.example.backend.repository.AuthorRepository;
 import com.example.backend.repository.BookRepository;
+import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,17 +21,15 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
+@RequiredArgsConstructor
 public class BookService implements IBookService {
     private static final Logger logger = LoggerFactory.getLogger(BookService.class);
 
-    @Autowired
-    private BookRepository bookRepository;
+    private final BookRepository bookRepository;
 
-    @Autowired
-    private AuthorRepository authorRepository;
+    private final AuthorRepository authorRepository;
 
-    @Autowired
-    private LibraryMapper libraryMapper;
+    private final LibraryMapper libraryMapper;
 
     @Override
     @Transactional(readOnly = true)

--- a/backend/src/main/java/com/example/backend/service/books/BookService.java
+++ b/backend/src/main/java/com/example/backend/service/books/BookService.java
@@ -37,12 +37,11 @@ public class BookService implements IBookService {
         logger.info("Fetching all books from the database");
         return bookRepository.findByDeletedFalse().stream()
                 .map(book -> {
-                    BookDTO bookDTO = libraryMapper.toBookDTO(book);
                     List<Author> authors = bookRepository.findAuthorsByBookId(book.getBookId());
-                    bookDTO.setAuthors(authors.stream()
-                            .map(libraryMapper::toAuthorSummaryDTO)
-                            .collect(Collectors.toSet()));
-                    return bookDTO;
+                    return libraryMapper.toBookDTO(book)
+                            .withAuthors(authors.stream()
+                                    .map(libraryMapper::toAuthorSummaryDTO)
+                                    .collect(Collectors.toSet()));
                 })
                 .collect(Collectors.toList());
     }
@@ -53,12 +52,11 @@ public class BookService implements IBookService {
         logger.info("Fetching book with id: {}", bookId);
         Book book = bookRepository.findById(bookId)
                 .orElseThrow(() -> new ResourceNotFoundException("Book not found with id: " + bookId));
-        BookDTO bookDTO = libraryMapper.toBookDTO(book);
         List<Author> authors = bookRepository.findAuthorsByBookId(book.getBookId());
-        bookDTO.setAuthors(authors.stream()
-                .map(libraryMapper::toAuthorSummaryDTO)
-                .collect(Collectors.toSet()));
-        return bookDTO;
+        return libraryMapper.toBookDTO(book)
+                .withAuthors(authors.stream()
+                        .map(libraryMapper::toAuthorSummaryDTO)
+                        .collect(Collectors.toSet()));
     }
 
     @Override
@@ -66,15 +64,15 @@ public class BookService implements IBookService {
     public BookDTO createBook(BookDTO bookDTO) {
         logger.info("Creating a new book");
         Book book = new Book();
-        book.setTitle(bookDTO.getTitle());
-        book.setIsbn(bookDTO.getIsbn());
-        book.setPublicationYear(bookDTO.getPublicationYear());
-        if (bookDTO.getStatus() != null) {
-            book.setStatus(Book.BookStatus.valueOf(bookDTO.getStatus()));
+        book.setTitle(bookDTO.title());
+        book.setIsbn(bookDTO.isbn());
+        book.setPublicationYear(bookDTO.publicationYear());
+        if (bookDTO.status() != null) {
+            book.setStatus(Book.BookStatus.valueOf(bookDTO.status()));
         }
-        book.setCoverImageUrl(bookDTO.getCoverImageUrl());
+        book.setCoverImageUrl(bookDTO.coverImageUrl());
 
-        Set<Author> authors = getPersistedAuthors(bookDTO.getAuthors());
+        Set<Author> authors = getPersistedAuthors(bookDTO.authors());
         book.setAuthors(authors);
 
         Book savedBook = bookRepository.save(book);
@@ -92,27 +90,27 @@ public class BookService implements IBookService {
             throw new IllegalStateException("Cannot update a deleted book");
         }
 
-        if (bookDTO.getTitle() != null) {
-            existingBook.setTitle(bookDTO.getTitle());
+        if (bookDTO.title() != null) {
+            existingBook.setTitle(bookDTO.title());
         }
-        if (bookDTO.getIsbn() != null) {
-            existingBook.setIsbn(bookDTO.getIsbn());
+        if (bookDTO.isbn() != null) {
+            existingBook.setIsbn(bookDTO.isbn());
         }
-        if (bookDTO.getPublicationYear() != null) {
-            existingBook.setPublicationYear(bookDTO.getPublicationYear());
+        if (bookDTO.publicationYear() != null) {
+            existingBook.setPublicationYear(bookDTO.publicationYear());
         }
 
-        if (bookDTO.getAuthors() != null && !bookDTO.getAuthors().isEmpty()) {
-            Set<Author> authors = getPersistedAuthors(bookDTO.getAuthors());
+        if (bookDTO.authors() != null && !bookDTO.authors().isEmpty()) {
+            Set<Author> authors = getPersistedAuthors(bookDTO.authors());
             existingBook.setAuthors(authors);
         }
 
-        if (bookDTO.getStatus() != null) {
-            existingBook.setStatus(Book.BookStatus.valueOf(bookDTO.getStatus()));
+        if (bookDTO.status() != null) {
+            existingBook.setStatus(Book.BookStatus.valueOf(bookDTO.status()));
         }
 
-        if (bookDTO.getCoverImageUrl() != null) {
-            existingBook.setCoverImageUrl(bookDTO.getCoverImageUrl());
+        if (bookDTO.coverImageUrl() != null) {
+            existingBook.setCoverImageUrl(bookDTO.coverImageUrl());
         }
 
         Book updatedBook = bookRepository.save(existingBook);
@@ -134,13 +132,13 @@ public class BookService implements IBookService {
     private Set<Author> getPersistedAuthors(Set<AuthorDTO.AuthorSummaryDTO> authorDTOs) {
         Set<Author> persistedAuthors = new HashSet<>();
         for (AuthorDTO.AuthorSummaryDTO authorDTO : authorDTOs) {
-            Optional<Author> existingAuthor = authorRepository.findByName(authorDTO.getName());
+            Optional<Author> existingAuthor = authorRepository.findByName(authorDTO.name());
             if (existingAuthor.isPresent()) {
                 persistedAuthors.add(existingAuthor.get());
             } else {
                 Author newAuthor = new Author();
-                newAuthor.setName(authorDTO.getName());
-                newAuthor.setNationality(authorDTO.getNationality());
+                newAuthor.setName(authorDTO.name());
+                newAuthor.setNationality(authorDTO.nationality());
                 persistedAuthors.add(authorRepository.save(newAuthor));
             }
         }

--- a/backend/src/main/java/com/example/backend/service/borrowers/BorrowerService.java
+++ b/backend/src/main/java/com/example/backend/service/borrowers/BorrowerService.java
@@ -7,9 +7,9 @@ import com.example.backend.mapper.LibraryMapper;
 import com.example.backend.model.Borrower;
 import com.example.backend.model.Borrowing;
 import com.example.backend.repository.BorrowerRepository;
+import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,14 +17,13 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
+@RequiredArgsConstructor
 public class BorrowerService implements IBorrowerService {
     private static final Logger logger = LoggerFactory.getLogger(BorrowerService.class);
 
-    @Autowired
-    private BorrowerRepository borrowerRepository;
+    private final BorrowerRepository borrowerRepository;
 
-    @Autowired
-    private LibraryMapper libraryMapper;
+    private final LibraryMapper libraryMapper;
 
     @Override
     @Transactional(readOnly = true)

--- a/backend/src/main/java/com/example/backend/service/borrowers/BorrowerService.java
+++ b/backend/src/main/java/com/example/backend/service/borrowers/BorrowerService.java
@@ -41,14 +41,12 @@ public class BorrowerService implements IBorrowerService {
 
         Borrower borrower = borrowerRepository.findById(borrowerID)
                 .orElseThrow(() -> new ResourceNotFoundException("Borrower not found with id: " + borrowerID));
-        BorrowerDTO borrowerDTO = libraryMapper.toBorrowerDTO(borrower);
 
         List<Borrowing> borrowings = borrowerRepository.findBorrowingByBorrowerId(borrower.getBorrowerId());
-        borrowerDTO.setBorrowings(borrowings.stream()
-                .map(libraryMapper::toBorrowingDTO)
-                .collect(Collectors.toSet()));
-
-        return borrowerDTO;
+        return libraryMapper.toBorrowerDTO(borrower)
+                .withBorrowings(borrowings.stream()
+                        .map(libraryMapper::toBorrowingDTO)
+                        .collect(Collectors.toSet()));
     }
 
     @Override
@@ -56,10 +54,10 @@ public class BorrowerService implements IBorrowerService {
     public BorrowerDTO createBorrower(BorrowerDTO.BorrowerSummaryDTO borrowerDTO) {
         logger.info("Creating a new borrower");
         Borrower borrower = new Borrower();
-        borrower.setPhone(borrowerDTO.getPhone());
-        borrower.setName(borrowerDTO.getName());
-        borrower.setAddress(borrowerDTO.getAddress());
-        borrower.setEmail(borrowerDTO.getEmail());
+        borrower.setPhone(borrowerDTO.phone());
+        borrower.setName(borrowerDTO.name());
+        borrower.setAddress(borrowerDTO.address());
+        borrower.setEmail(borrowerDTO.email());
 
         Borrower savedBorrower = borrowerRepository.save(borrower);
         logger.info("Borrower created successfully with id: {}", savedBorrower.getBorrowerId());
@@ -76,20 +74,20 @@ public class BorrowerService implements IBorrowerService {
             throw new IllegalStateException("Cannot update a deleted borrower");
         }
 
-        if (patch.getName() != null) {
-            existingBorrower.setName(patch.getName());
+        if (patch.name() != null) {
+            existingBorrower.setName(patch.name());
         }
-        if (patch.getEmail() != null) {
-            existingBorrower.setEmail(patch.getEmail());
+        if (patch.email() != null) {
+            existingBorrower.setEmail(patch.email());
         }
-        if (patch.getPhone() != null) {
-            existingBorrower.setPhone(patch.getPhone());
+        if (patch.phone() != null) {
+            existingBorrower.setPhone(patch.phone());
         }
-        if (patch.getAddress() != null) {
-            existingBorrower.setAddress(patch.getAddress());
+        if (patch.address() != null) {
+            existingBorrower.setAddress(patch.address());
         }
-        if (patch.getStatus() != null) {
-            existingBorrower.setStatus(Borrower.BorrowerStatus.valueOf(patch.getStatus()));
+        if (patch.status() != null) {
+            existingBorrower.setStatus(Borrower.BorrowerStatus.valueOf(patch.status()));
         }
 
         Borrower updatedBorrower = borrowerRepository.save(existingBorrower);

--- a/backend/src/main/java/com/example/backend/service/borrowing/BorrowingService.java
+++ b/backend/src/main/java/com/example/backend/service/borrowing/BorrowingService.java
@@ -34,6 +34,7 @@ public class BorrowingService implements IBorrowingService {
     private final LibraryMapper libraryMapper;
 
     @Override
+    @Transactional(readOnly = true)
     public List<BorrowingDTO> getAllBorrowings() {
         logger.info("Fetching all borrowings from the database");
         List<Borrowing> borrowings = borrowingRepository.findAll();
@@ -44,6 +45,7 @@ public class BorrowingService implements IBorrowingService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public BorrowingDTO getBorrowingById(Long borrowingId) {
         logger.info("Fetching borrowing with id: {}", borrowingId);
         Borrowing borrowing = borrowingRepository.findById(borrowingId)

--- a/backend/src/main/java/com/example/backend/service/borrowing/BorrowingService.java
+++ b/backend/src/main/java/com/example/backend/service/borrowing/BorrowingService.java
@@ -9,9 +9,9 @@ import com.example.backend.model.Borrowing;
 import com.example.backend.repository.BookRepository;
 import com.example.backend.repository.BorrowerRepository;
 import com.example.backend.repository.BorrowingRepository;
+import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,21 +20,18 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
+@RequiredArgsConstructor
 public class BorrowingService implements IBorrowingService {
 
     private static final Logger logger = LoggerFactory.getLogger(BorrowingService.class);
 
-    @Autowired
-    private BorrowingRepository borrowingRepository;
+    private final BorrowingRepository borrowingRepository;
 
-    @Autowired
-    private BookRepository bookRepository;
+    private final BookRepository bookRepository;
 
-    @Autowired
-    private BorrowerRepository borrowerRepository;
+    private final BorrowerRepository borrowerRepository;
 
-    @Autowired
-    private LibraryMapper libraryMapper;
+    private final LibraryMapper libraryMapper;
 
     @Override
     public List<BorrowingDTO> getAllBorrowings() {

--- a/backend/src/main/java/com/example/backend/service/borrowing/BorrowingService.java
+++ b/backend/src/main/java/com/example/backend/service/borrowing/BorrowingService.java
@@ -59,20 +59,20 @@ public class BorrowingService implements IBorrowingService {
     public BorrowingDTO createBorrowing(BorrowingDTO borrowingDTO) {
         logger.info("Creating a new borrowing");
 
-        Book book = bookRepository.findById(borrowingDTO.getBookId())
-                .orElseThrow(() -> new ResourceNotFoundException("Book not found with id: " + borrowingDTO.getBookId()));
+        Book book = bookRepository.findById(borrowingDTO.bookId())
+                .orElseThrow(() -> new ResourceNotFoundException("Book not found with id: " + borrowingDTO.bookId()));
 
         if (book.getStatus() != Book.BookStatus.AVAILABLE) {
             throw new IllegalStateException(
                     "Book is not available for borrowing (current status: " + book.getStatus() + ")");
         }
 
-        Borrower borrower = borrowerRepository.findById(borrowingDTO.getBorrowerId())
-                .orElseThrow(() -> new ResourceNotFoundException("Borrower not found with id: " + borrowingDTO.getBorrowerId()));
+        Borrower borrower = borrowerRepository.findById(borrowingDTO.borrowerId())
+                .orElseThrow(() -> new ResourceNotFoundException("Borrower not found with id: " + borrowingDTO.borrowerId()));
 
         Borrowing borrowing = new Borrowing();
         borrowing.setBorrowedDate(LocalDate.now());
-        borrowing.setDueDate(borrowingDTO.getDueDate());
+        borrowing.setDueDate(borrowingDTO.dueDate());
         borrowing.setStatus(Borrowing.BorrowingStatus.BORROWED);
         borrowing.setBorrower(borrower);
         borrowing.setBook(book);
@@ -93,29 +93,29 @@ public class BorrowingService implements IBorrowingService {
         Borrowing existingBorrowing = borrowingRepository.findById(borrowingId)
                 .orElseThrow(() -> new ResourceNotFoundException("Borrowing not found with id: " + borrowingId));
 
-        if (borrowingDTO.getBorrowerId() != null) {
-            Borrower borrower = borrowerRepository.findById(borrowingDTO.getBorrowerId())
-                    .orElseThrow(() -> new ResourceNotFoundException("Borrower not found with id: " + borrowingDTO.getBorrowerId()));
+        if (borrowingDTO.borrowerId() != null) {
+            Borrower borrower = borrowerRepository.findById(borrowingDTO.borrowerId())
+                    .orElseThrow(() -> new ResourceNotFoundException("Borrower not found with id: " + borrowingDTO.borrowerId()));
             existingBorrowing.setBorrower(borrower);
         }
-        if (borrowingDTO.getBookId() != null) {
-            Book book = bookRepository.findById(borrowingDTO.getBookId())
-                    .orElseThrow(() -> new ResourceNotFoundException("Book not found with id: " + borrowingDTO.getBookId()));
+        if (borrowingDTO.bookId() != null) {
+            Book book = bookRepository.findById(borrowingDTO.bookId())
+                    .orElseThrow(() -> new ResourceNotFoundException("Book not found with id: " + borrowingDTO.bookId()));
             existingBorrowing.setBook(book);
         }
-        if (borrowingDTO.getBorrowedDate() != null) {
-            existingBorrowing.setBorrowedDate(borrowingDTO.getBorrowedDate());
+        if (borrowingDTO.borrowedDate() != null) {
+            existingBorrowing.setBorrowedDate(borrowingDTO.borrowedDate());
         }
-        if (borrowingDTO.getDueDate() != null) {
-            existingBorrowing.setDueDate(borrowingDTO.getDueDate());
-        }
-
-        if (borrowingDTO.getReturnedDate() != null) {
-            existingBorrowing.setReturnedDate(borrowingDTO.getReturnedDate());
+        if (borrowingDTO.dueDate() != null) {
+            existingBorrowing.setDueDate(borrowingDTO.dueDate());
         }
 
-        if (borrowingDTO.getStatus() != null) {
-            existingBorrowing.setStatus(Borrowing.BorrowingStatus.valueOf(borrowingDTO.getStatus()));
+        if (borrowingDTO.returnedDate() != null) {
+            existingBorrowing.setReturnedDate(borrowingDTO.returnedDate());
+        }
+
+        if (borrowingDTO.status() != null) {
+            existingBorrowing.setStatus(Borrowing.BorrowingStatus.valueOf(borrowingDTO.status()));
             if (existingBorrowing.getStatus().equals(Borrowing.BorrowingStatus.RETURNED)) {
                 Book book = existingBorrowing.getBook();
                 book.setStatus(Book.BookStatus.AVAILABLE);

--- a/backend/src/main/resources/application-docker.properties
+++ b/backend/src/main/resources/application-docker.properties
@@ -6,6 +6,7 @@ spring.jpa.hibernate.ddl-auto=none
 spring.jpa.show-sql=false
 spring.jpa.open-in-view=false
 spring.sql.init.mode=never
+spring.threads.virtual.enabled=true
 server.port=8080
 app.cors.allowed-origins=http://localhost:5173
 spring.security.user.name=librarian

--- a/backend/src/main/resources/application.properties.example
+++ b/backend/src/main/resources/application.properties.example
@@ -22,6 +22,11 @@ spring.sql.init.mode=never
 # --- Server ---
 server.port=8080
 
+# --- Concurrency ---
+# Virtual threads (JDK 21+, recommended on JDK 25) for the web server and
+# async executors. Frees platform threads on blocking JPA/JDBC calls.
+spring.threads.virtual.enabled=true
+
 # --- CORS ---
 # Comma-separated list of allowed front-end origins.
 app.cors.allowed-origins=http://localhost:5173

--- a/backend/src/test/java/com/example/backend/dto/DtoJsonContractTest.java
+++ b/backend/src/test/java/com/example/backend/dto/DtoJsonContractTest.java
@@ -1,0 +1,93 @@
+package com.example.backend.dto;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.json.JsonTest;
+import org.springframework.boot.test.json.JacksonTester;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that the record-based DTOs serialize/deserialize through the
+ * Spring-configured Jackson mapper with the same JSON contract as before the
+ * record migration (field names = component names, request binding via the
+ * canonical constructor).
+ */
+@JsonTest
+class DtoJsonContractTest {
+
+    @Autowired
+    private JacksonTester<BookDTO> bookJson;
+
+    @Autowired
+    private JacksonTester<BorrowingDTO> borrowingJson;
+
+    @Autowired
+    private JacksonTester<BorrowerPatchDTO> patchJson;
+
+    @Test
+    void bookDtoSerializesWithExpectedKeys() throws Exception {
+        BookDTO dto = new BookDTO(
+                1L, "Dune", "9780441013593", 1965,
+                Set.of(new AuthorDTO.AuthorSummaryDTO(7L, "Frank Herbert", "American", null)),
+                "AVAILABLE", "http://cover");
+
+        assertThat(bookJson.write(dto))
+                .hasJsonPath("$.bookId")
+                .hasJsonPath("$.title")
+                .hasJsonPath("$.isbn")
+                .hasJsonPath("$.publicationYear")
+                .hasJsonPath("$.authors")
+                .hasJsonPath("$.status")
+                .hasJsonPath("$.coverImageUrl")
+                // nested summary keys
+                .hasJsonPath("$.authors[0].id")
+                .hasJsonPath("$.authors[0].name")
+                .hasJsonPath("$.authors[0].nationality")
+                .hasJsonPath("$.authors[0].portraitUrl");
+    }
+
+    @Test
+    void bookDtoDeserializesFromRequestJson() throws Exception {
+        String json = """
+                {
+                  "title": "Dune",
+                  "isbn": "9780441013593",
+                  "publicationYear": 1965,
+                  "status": "AVAILABLE",
+                  "authors": [{"id": 7, "name": "Frank Herbert", "nationality": "American"}]
+                }
+                """;
+        BookDTO dto = bookJson.parseObject(json);
+        assertThat(dto.title()).isEqualTo("Dune");
+        assertThat(dto.isbn()).isEqualTo("9780441013593");
+        assertThat(dto.publicationYear()).isEqualTo(1965);
+        assertThat(dto.bookId()).isNull(); // omitted -> null, as before
+        assertThat(dto.authors()).hasSize(1);
+        assertThat(dto.authors().iterator().next().name()).isEqualTo("Frank Herbert");
+    }
+
+    @Test
+    void borrowingDtoRoundTripsTimestamps() throws Exception {
+        BorrowingDTO dto = new BorrowingDTO(
+                5L, 1L, 2L,
+                LocalDate.of(2026, 1, 1), LocalDate.of(2026, 2, 1), null,
+                LocalDateTime.of(2026, 1, 1, 10, 30), LocalDateTime.of(2026, 1, 1, 10, 30),
+                "BORROWED");
+        BorrowingDTO back = borrowingJson.parseObject(borrowingJson.write(dto).getJson());
+        assertThat(back).isEqualTo(dto);
+        assertThat(back.createdAt()).isEqualTo(LocalDateTime.of(2026, 1, 1, 10, 30));
+    }
+
+    @Test
+    void patchDtoOmittedFieldsAreNull() throws Exception {
+        BorrowerPatchDTO dto = patchJson.parseObject("{\"name\": \"Alice\"}");
+        assertThat(dto.name()).isEqualTo("Alice");
+        assertThat(dto.email()).isNull();
+        assertThat(dto.status()).isNull();
+    }
+}


### PR DESCRIPTION
Follow-up cleanup after the Spring Boot 4.0 / Java 25 upgrade — closes the gaps the upgrade left and applies the optimizations the new runtime enables. Each logical fix is its own commit.

## Changes

| Commit | What & why |
|---|---|
| `build: enforce JDK 25 via maven-enforcer-plugin` | `java.version=25` was declared but unenforced — a clean compile on JDK <25 failed with a cryptic `release version 25 not supported`, and an incremental build could falsely report success from stale classes. Now fails fast at `validate` with a clear message. |
| `perf(backend): enable virtual threads` | `spring.threads.virtual.enabled=true` for the runtime profile. On JDK 25 + Boot 4, blocking JPA/JDBC request handling scales on virtual threads instead of pinning a small platform-thread pool. |
| `refactor(backend): use constructor injection in controllers and services` | Replaces all 15 `@Autowired` field injections with Lombok `@RequiredArgsConstructor` over `final` fields. Immutable, explicit dependencies; unit-constructable without reflection. |
| `fix(backend): store Borrowing audit timestamps as LocalDateTime` | `borrowings.created_at/updated_at` are `TIMESTAMP WITH TIME ZONE`, but the entity mapped them to `LocalDate` — `@CreationTimestamp`/`@UpdateTimestamp` were silently truncating the time-of-day. Now `LocalDateTime`, matching the schema and the other entities. |
| `fix(backend): lazy-fetch Borrowing relations and mark reads read-only` | `@ManyToOne` defaulted to EAGER (N+1 on borrowing lists). Made `book`/`borrower` LAZY — safe because the mapper only reads their identifiers and all read paths are transactional with `open-in-view=false`. Also added `@Transactional(readOnly = true)` to the two `Borrowing` read methods for consistency. |
| `refactor(backend): convert DTOs to records` | All DTOs + nested summaries are now records (no more Lombok `@Data`). Mapper builds via canonical constructors; services use accessors and small `withX()` copy methods. Also populates the previously-unmapped `createdAt`/`updatedAt` on `BorrowerDTO`/`BorrowingDTO` (were always `null`). |

## Behavioral note

The only observable change: `BorrowerDTO`/`BorrowingDTO` `createdAt`/`updatedAt` go from always-`null` to real timestamps (those JSON keys already existed). Additive — low frontend risk.

## Verification

- `mvnw clean verify` on JDK 25: `BUILD SUCCESS`, `Tests run: 5, Failures: 0`.
- New `DtoJsonContractTest` (`@JsonTest`) proves the record migration preserves the JSON API contract: identical keys (incl. nested summaries), canonical-constructor request binding, PATCH null semantics, and timestamp round-trip.
- The enforcer guard was confirmed to fail on JDK 17 and pass on JDK 25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)